### PR TITLE
CI: fix upload-artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,7 +225,7 @@ jobs:
           -c container_images
           -i intellabs/kafl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docker-bench-security
           path: bench-logs/


### PR DESCRIPTION
https://github.com/IntelLabs/kAFL/actions/runs/13270501987/job/37048559795?pr=309
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
